### PR TITLE
Add missing left angle brackets to make XML files valid

### DIFF
--- a/mads/PrimaryAuthors/J/John, of Damascus, Saint/n80-32173.xml.mads.xml
+++ b/mads/PrimaryAuthors/J/John, of Damascus, Saint/n80-32173.xml.mads.xml
@@ -27,7 +27,7 @@
   <mads:variant type="other">
     <mads:name type="personal">
       <mads:namePart>Ioann</mads:namePart>
-      <mads:namePart type="termsOfAddress">of Damascus/mads:namePart>
+      <mads:namePart type="termsOfAddress">of Damascus</mads:namePart>
     </mads:name>
   </mads:variant>
   <mads:variant type="other">
@@ -45,7 +45,7 @@
   <mads:variant type="other">
     <mads:name type="personal">
       <mads:namePart>Jan</mads:namePart>
-      <mads:namePart type="termsOfAddress">van Damascus/mads:namePart>
+      <mads:namePart type="termsOfAddress">van Damascus</mads:namePart>
     </mads:name>
   </mads:variant>
   <mads:variant type="other">

--- a/mads/PrimaryAuthors/L/Labeo, Attius/nr95-21126.mads.xml
+++ b/mads/PrimaryAuthors/L/Labeo, Attius/nr95-21126.mads.xml
@@ -26,7 +26,7 @@
   <mads:url displayLabel="Id.gov">http://id.loc.gov/authorities/names/nr95021126</mads:url>
   <mads:url displayLabel="Wikipedia">https://en.wikipedia.org/wiki/Attius_Labeo</mads:url>
   <mads:url displayLabel="Worldcat Identities">http://worldcat.org/identities/lccn-nr95-21126</mads:url>
-  <mads:url displayLabel="Smith's Dictionary">
+  <mads:url displayLabel="Smith's Dictionary"/>
   <mads:identifier type="phi">908</mads:identifier>
   <mads:extension>
     <mads:description>List of related work identifiers</mads:description>

--- a/mads/PrimaryAuthors/Q/Quintus Smyrnaeus/n84-58406.xml.mads.xml
+++ b/mads/PrimaryAuthors/Q/Quintus Smyrnaeus/n84-58406.xml.mads.xml
@@ -77,7 +77,7 @@
   <mads:identifier type="lccn">n  84058406 </mads:identifier>
   <mads:fieldOfActivity>Historian</mads:fieldOfActivity>
   <mads:fieldOfActivity>Epigrammatist</mads:fieldOfActivity>
-  mads:url displayLabel="VIAF">http://viaf.org/viaf/76294608</mads:url>
+  <mads:url displayLabel="VIAF">http://viaf.org/viaf/76294608</mads:url>
   <mads:url displayLabel="Wikipedia">http://en.wikipedia.org/wiki/Quintus_Smyrnaeus</mads:url>
   <mads:url displayLabel="Worldcat Identities">http://www.worldcat.org/wcidentities/lccn-n84-58406</mads:url>
   <mads:url displayLabel="Smith's Dictionary"/>


### PR DESCRIPTION
Three MADS files were missing angle brackets or closing slashes.